### PR TITLE
docs: restructure documentation into three-tier hierarchy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md
+
+Python CLI that imports multi-bank CSV/Excel statements, classifies expenses via OpenAI (with optional Tavily search enrichment), and exports to Excel.
+
+## Commands
+
+```sh
+uv sync                                # Install dependencies
+uv run python -m import_bank_details.main  # Run pipeline
+./run_tests.sh                         # Run all tests
+./run_tests.sh --unit                  # Unit tests only
+uv run black --check .                 # Check formatting
+uv run flake8 .                        # Lint
+uv run isort --check .                 # Check import order
+uv run mypy .                          # Type check
+```
+
+## Key Constraints
+
+- Python 3.11+
+- Line length: 130 (Black + isort + Flake8)
+- mypy: strict (`disallow_untyped_defs`, `warn_return_any`), tests exempted
+- Test coverage: minimum 80%
+- API keys required: `OPENAI_API_KEY`, `TAVILY_API_KEY` (in `.env`)
+
+## Documentation
+
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — Tech stack, system overview, data flow, design decisions
+- [docs/ABSTRACTIONS.md](docs/ABSTRACTIONS.md) — Domain models, configuration formats, classification pipeline
+- [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) — Directory structure, how to extend, testing, CI/CD

--- a/README.md
+++ b/README.md
@@ -3,143 +3,61 @@
 [![CI](https://github.com/giampaolocasolla/import-bank-details/actions/workflows/ci.yml/badge.svg)](https://github.com/giampaolocasolla/import-bank-details/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/giampaolocasolla/import-bank-details/branch/main/graph/badge.svg)](https://codecov.io/gh/giampaolocasolla/import-bank-details)
 
-This project is designed to import, process, and classify bank details from various sources. It reads data from CSV or Excel files, processes the data according to specified configurations, classifies expenses using OpenAI's language model (with optional online search augmentation), and outputs the processed data to an Excel file.
+Import, process, and classify bank statements from multiple sources. Reads CSV/Excel exports from various banks, classifies expenses using OpenAI with optional Tavily search enrichment, and outputs a consolidated Excel file.
 
 ## Features
 
-- **Import Data from Multiple Banks**: Supports Curve, ING, N26, Revolut, and more.
-- **Data Cleaning and Processing**: Cleans and processes data based on configurable settings.
-- **Parallel Expense Classification**:
-  - Classifies expenses in parallel to significantly speed up processing time.
-  - The number of parallel workers can be configured in `import_bank_details/main.py`.
-- **Primary Classification**: Uses OpenAI's GPT model to categorize expenses.
-- **Enhanced Classification**: Optionally integrates online search results to improve classification accuracy.
-- **Online Search Integration**: Fetches additional information from Tavily to augment expense classification.
-- **Output to Excel**: Exports the processed and classified data to an Excel file for easy review and analysis.
+- **Multi-bank support** — Curve, ING, N26, Revolut (configuration-driven, easy to extend)
+- **Parallel AI classification** — Expenses classified concurrently via OpenAI Responses API with Pydantic structured output
+- **Search-augmented classification** — Optional Tavily search enrichment for improved accuracy on ambiguous expenses
+- **Few-shot learning** — Example-based prompting from historical classifications
+- **Configurable** — Bank mappings, categories, LLM settings all defined in YAML
 
 ## Requirements
 
-- **Python 3.11** or higher
-- **uv** for dependency management
-- **OpenAI API Key**
-- **Tavily API Key**
+- Python 3.11+
+- [uv](https://github.com/astral-sh/uv) for dependency management
+- OpenAI API key
+- Tavily API key
 
 ## Installation
 
-1. **Clone the Repository**:
+```sh
+git clone https://github.com/giampaolocasolla/import-bank-details.git
+cd import-bank-details
+uv sync
+```
 
-    ```sh
-    git clone https://github.com/giampaolocasolla/import-bank-details.git
-    cd import-bank-details
-    ```
+Create a `.env` file in the project root:
 
-2. **Install uv (if not already installed)**:
-
-    ```sh
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    ```
-
-3. **Install Dependencies Using uv**:
-
-    ```sh
-    uv sync
-    ```
-
-4. **Set Up Your API Keys**:
-    - Create a `.env` file in the project root.
-    - Add your OpenAI and Tavily API keys:
-
-      ```
-      OPENAI_API_KEY="your_openai_api_key"
-      TAVILY_API_KEY="your_tavily_api_key"
-      ```
+```
+OPENAI_API_KEY="your_openai_api_key"
+TAVILY_API_KEY="your_tavily_api_key"
+```
 
 ## Usage
-
-Run the main script to process and classify the bank details:
 
 ```sh
 uv run python -m import_bank_details.main
 ```
 
-### Classification with Online Search
-
-The application can perform online searches to gather additional context for classifying expenses. This feature is powered by Tavily and can be enabled by setting `include_online_search=True` when calling `classify_expenses`.
-The search results are cached to improve performance and reduce redundant searches.
-The cache is stored in `data/examples/search_cache.json`.
-
-Example:
-
-```python
-classification = get_classification(
-    expense_input=expense_data,
-    include_online_search=True
-)
-```
+Place bank export files in `data/{bank_name}/` and the pipeline will automatically pick up the most recent file from each subfolder.
 
 ## Testing
 
-Run the test suite using the provided test script:
-
 ```sh
-./run_tests.sh
+./run_tests.sh              # All tests
+./run_tests.sh --unit       # Unit tests only
+./run_tests.sh --integration # Integration tests only
 ```
 
-The script offers several options:
+## Documentation
 
-- `--help`: Show usage information
-- `--verbose`, `-v`: Run tests in verbose mode
-- `--all`: Run all tests (default)
-- `--unit`: Run only unit tests
-- `--integration`: Run only integration tests
-- `--extra PATTERN`: Run tests matching the given pattern
+See [`docs/`](docs/) for detailed documentation:
 
-The test output is color-coded:
-- Green: Successful test results
-- Red: Failed tests or errors
-- Yellow: Informational messages
-
-Example usage:
-```sh
-# Run all tests
-./run_tests.sh
-
-# Run only unit tests in verbose mode
-./run_tests.sh --unit -v
-
-# Run tests matching a specific pattern
-./run_tests.sh --extra "test_import"
-```
-
-## CI/CD Pipeline
-
-This project uses GitHub Actions for Continuous Integration and Continuous Deployment:
-
-- **Automated Tests**: All tests are automatically run on each push and pull request.
-- **Code Quality Checks**:
-  - Code formatting with Black
-  - Linting with Flake8
-  - Import sorting with isort
-  - Type checking with mypy
-  - Pre-commit hook verification
-- **Test Coverage**: Coverage reports are generated and uploaded to Codecov.
-
-You can see the status of these checks on any pull request or in the Actions tab of the GitHub repository.
-
-## Configuration
-
-- **`config_bank.yaml`**: Specifies the import settings and column mappings for different banks.
-- **`config_llm.yaml`**: Contains configuration for the OpenAI language model used for expense classification.
-
-Ensure that these files are correctly set up before running the script.
-
-## Expense Classification
-
-The project uses OpenAI's GPT model to classify expenses into primary and secondary categories. The classification is based on the expense name, amount, and other details. With the optional online search functionality, the classification process can be augmented with additional context fetched from Tavily, enhancing accuracy for ambiguous or less common expense names.
-
-### Classification Examples
-
-The `data/examples` directory contains a CSV file with example classifications. This file is used to provide few-shot examples to the language model, which improves the accuracy of the classification.
+- [Architecture](docs/ARCHITECTURE.md) — Tech stack, system overview, data flow, design decisions
+- [Abstractions](docs/ABSTRACTIONS.md) — Domain models, configuration formats, classification pipeline
+- [Getting Started](docs/GETTING_STARTED.md) — Directory structure, how to extend, testing, CI/CD
 
 ## License
 

--- a/docs/ABSTRACTIONS.md
+++ b/docs/ABSTRACTIONS.md
@@ -1,0 +1,125 @@
+# Abstractions
+
+Key domain concepts and data models the project is invested in.
+
+## Bank Configuration Model
+
+Defined in `config_bank.yaml`. Each bank is a top-level YAML key with:
+
+| Field | Purpose | Example |
+|---|---|---|
+| `import` | Pandas `read_csv` kwargs (separator, encoding, etc.) | `sep: ";"` |
+| `columns_old` | Original column names in the bank's export | `["Date", "Bénéficiaire", "Montant", "Bank", "Communication"]` |
+| `columns_new` | Standardized column names | `["Day", "Expense_name", "Amount", "Bank", "Comment"]` |
+| `Day` | `strftime` format string for date parsing | `"%d/%m/%Y"` |
+| `Remove` | (optional) Strings to filter out of `Expense_name` | `["Giampaolo Casolla"]` (internal transfers) |
+
+The `Bank` column is auto-filled with the subfolder name. If `Bank` appears in `columns_old`, the folder name is assigned before renaming.
+
+**Supported banks:** Curve, ING, N26, Revolut (English and Italian variants).
+
+Revolut has automatic format detection — `detect_bank_config()` in `main.py` reads the CSV header and selects `revolut` or `revolut_it` configuration.
+
+## Category Taxonomy
+
+Defined in `import_bank_details/categories.yaml`. A hierarchical YAML structure:
+
+```yaml
+Housing:
+  - Rent
+  - Internet
+  - Furniture
+  # ...
+
+Transport:
+  - Fuel
+  - PublicTransport
+  # ...
+```
+
+**Primary categories:** Housing, Transport, Groceries, Travel, Out, Leisure, Health, Gifts, Clothing, Fees, OtherExpenses.
+
+Each primary category has a list of secondary categories (subcategories).
+
+### ExpenseType Enum
+
+`structured_output.py:load_expense_type_enum()` reads the YAML at import time and dynamically generates a Python `Enum`:
+
+- Each enum member name is `SUBCATEGORY_UPPER` (e.g., `RENT`, `FUEL`)
+- Each enum value is `"Primary, Secondary"` (e.g., `"Housing, Rent"`, `"Transport, Fuel"`)
+- Collisions are resolved by prefixing with the primary category (e.g., `LEISURE_LEISURE` for `Leisure > Leisure` vs `OUT_LEISURE` for `Out > Leisure`)
+
+## Expense Data Models
+
+Defined in `structured_output.py` using Pydantic:
+
+### ExpenseInput
+```
+Day: str           # "dd/mm/yyyy"
+Expense_name: str  # Raw description from bank
+Amount: str        # Numeric string (e.g., "42.50")
+Bank: str          # Bank/folder name
+Comment: str       # Additional info (payment type, reference, etc.)
+```
+
+### ExpenseOutput
+```
+expense_type: ExpenseType   # The dynamically generated enum
+├── .category    → str      # Primary category (property)
+└── .subcategory → str      # Secondary category (property)
+```
+
+Validation via `@field_validator` ensures only valid `ExpenseType` members are accepted.
+
+### ExpenseEntry
+```
+input: ExpenseInput
+output: Optional[ExpenseOutput]   # None before classification
+```
+
+### Pipeline flow
+`ExpenseInput` → classification → `ExpenseOutput` → combined into `ExpenseEntry`
+
+## Classification Pipeline
+
+1. **Build few-shot examples** — Convert `data/examples/*.csv` rows into `ExpenseEntry` objects with known outputs, then serialize as `{"input": {...}, "output": "Primary, Secondary"}` pairs.
+
+2. **Optional search enrichment** — If `include_online_search=True`, call `perform_online_search()` which queries Tavily for the expense name (with a Germany country filter, falling back without), caches results, and appends them to the user message.
+
+3. **LLM call** — Send system prompt (from `config_llm.yaml`) + optional category list + few-shot messages + user message to `openai.responses.parse()`. The response is constrained to the `ExpenseOutput` Pydantic schema.
+
+4. **Validation** — Pydantic validates that the returned `expense_type` is a valid `ExpenseType` enum member.
+
+Negative amounts (income/refunds) skip classification entirely.
+
+## LLM Configuration
+
+Defined in `config_llm.yaml`:
+
+```yaml
+llm:
+  model_name: "gpt-5-mini"
+  timeout: 180
+
+system_prompt: "You are an helpful assistant that classifies expenses into categories and subcategories."
+```
+
+The system prompt is augmented at runtime with the full nested category list when `include_categories_in_prompt=True`.
+
+## Search and Caching
+
+### SearchCache class (`search.py`)
+
+- **Thread-safe**: All access goes through a `threading.Lock`
+- **Lazy-loaded**: Disk cache is read on first access, not at init
+- **Disk-persistent**: Written to `data/examples/search_cache.json` after every new entry
+- **Rate-limited**: Minimum 0.7s between Tavily API requests
+- **Retry-ready**: Configurable `max_retries` (default 3) and `initial_delay` (default 2.0s) for exponential backoff
+
+### Input cleaning
+
+Before searching, common prefixes are stripped: `SumUp  *`, `PAYPAL *`, `LSP*`, `CRV*`, `PAY.nl*`, `UZR*`, `luca `.
+
+### Cache key format
+
+`"{cleaned_name}:{max_results}"` — so different `max_results` values produce separate cache entries.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,80 @@
+# Architecture
+
+## Tech Stack
+
+| Component | Technology |
+|---|---|
+| Language | Python 3.11+ |
+| Package manager | [uv](https://github.com/astral-sh/uv) |
+| LLM | OpenAI Responses API (default model: `gpt-5-mini`) |
+| Web search | [Tavily](https://tavily.com/) |
+| Data processing | Pandas |
+| Structured output | Pydantic |
+| Excel I/O | openpyxl |
+| Configuration | YAML (`PyYAML`) |
+| Progress bars | tqdm |
+
+## System Overview
+
+```
+ CSV / Excel files (per bank)
+        │
+        ▼
+ ┌──────────────┐
+ │   Import      │  Read files, apply bank-specific import params
+ └──────┬───────┘
+        ▼
+ ┌──────────────┐
+ │   Process     │  Select/rename columns, parse dates, filter rows
+ └──────┬───────┘
+        ▼
+ ┌──────────────┐
+ │   Classify    │  Parallel AI classification (ThreadPoolExecutor)
+ │               │  Few-shot examples + optional Tavily search
+ │               │  → OpenAI structured output → Pydantic validation
+ └──────┬───────┘
+        ▼
+ ┌──────────────┐
+ │   Export      │  Write classified DataFrame to Excel
+ └──────────────┘
+```
+
+## Data Flow
+
+1. **Import** — `main.py:get_latest_files()` scans `data/` subfolders and picks the most recently modified file per bank. Each file is read with `import_data()` using bank-specific CSV parameters (separator, encoding) or falls back to Excel.
+
+2. **Process** — `process_data()` selects and renames columns per `config_bank.yaml`, removes unwanted rows (e.g., internal transfers), and parses dates. Bank-specific format detection handles variants like Italian vs English Revolut exports (`detect_bank_config()`).
+
+3. **Classify** — `classify_expenses()` sends each expense to OpenAI in parallel via `ThreadPoolExecutor` (default 10 workers). Each request includes few-shot examples from `data/examples/*.csv` and optionally Tavily search results. The LLM returns a structured `ExpenseOutput` (Pydantic model) containing `ExpenseType` — a dynamically generated enum from `categories.yaml`.
+
+4. **Export** — `save_to_excel()` writes the classified DataFrame to `output/` as an Excel file named `{latest_date}_{banks}.xlsx`.
+
+## Key Architectural Decisions
+
+### Configuration-driven bank support
+Each bank is defined in `config_bank.yaml` with column mappings (`columns_old` → `columns_new`), date format, optional import parameters (e.g., CSV separator), and optional row-removal filters. Adding a new bank requires only a new YAML block — no code changes.
+
+### Parallel classification with ThreadPoolExecutor
+Expenses are classified concurrently (configurable `max_workers`, default 10) to minimize wall-clock time. Progress is tracked via `tqdm`. Each worker is independent — no shared mutable state beyond the thread-safe search cache.
+
+### Structured outputs via Pydantic + OpenAI Responses API
+Classification results are parsed directly into `ExpenseOutput` using `openai.responses.parse()`, which enforces the Pydantic schema on the LLM response. This guarantees type-safe, validated output without manual JSON parsing.
+
+### Dynamically generated ExpenseType enum
+`structured_output.py:load_expense_type_enum()` reads `categories.yaml` at import time and builds an `Enum` class. This means adding or renaming categories only requires editing the YAML file.
+
+### Thread-safe search result caching with disk persistence
+`SearchCache` (in `search.py`) uses a threading lock to protect concurrent reads/writes. Results are persisted to `data/examples/search_cache.json` so repeated runs reuse previous lookups. Rate limiting (min 0.7s between requests) is built in.
+
+### Exponential backoff retry for external API calls
+Both OpenAI calls (`get_classification`) and Tavily searches (`perform_online_search`) implement retry loops with exponential backoff (default 3 attempts) to handle transient failures gracefully.
+
+### Modular separation of concerns
+| Module | Responsibility |
+|---|---|
+| `main.py` | Pipeline orchestration, file I/O |
+| `classification.py` | LLM interaction, parallel classification |
+| `search.py` | Tavily search, caching, rate limiting |
+| `structured_output.py` | Pydantic models, dynamic enum generation |
+| `utils.py` | YAML config loading |
+| `logger_setup.py` | Logging configuration |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,143 @@
+# Getting Started
+
+Practical guidance for working with the codebase.
+
+## Directory Structure
+
+```
+import-bank-details/
+├── import_bank_details/       # Main package
+│   ├── main.py                # Pipeline orchestration, file I/O
+│   ├── classification.py      # LLM classification, parallel processing
+│   ├── search.py              # Tavily search, caching, rate limiting
+│   ├── structured_output.py   # Pydantic models, dynamic ExpenseType enum
+│   ├── utils.py               # YAML config loading
+│   ├── logger_setup.py        # Logging configuration
+│   └── categories.yaml        # Category taxonomy (primary → secondary)
+├── tests/                     # Test suite (unit, integration, e2e)
+├── data/                      # Input data (one subfolder per bank)
+│   └── examples/              # Few-shot CSV + search_cache.json
+├── output/                    # Generated Excel files
+├── config_bank.yaml           # Bank import settings and column mappings
+├── config_llm.yaml            # LLM model selection and system prompt
+├── run_tests.sh               # Test runner script
+├── pyproject.toml             # Dependencies, tool config
+└── .github/workflows/         # CI pipeline (ci.yml, pre-commit.yml)
+```
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `main.py` | Entry point; scans `data/`, imports, processes, classifies, exports |
+| `classification.py` | Builds few-shot messages, calls OpenAI in parallel, returns classified DataFrame |
+| `search.py` | `SearchCache` class and `perform_online_search()` for Tavily lookups |
+| `structured_output.py` | `ExpenseInput`, `ExpenseOutput`, `ExpenseEntry` models; dynamic `ExpenseType` enum |
+| `utils.py` | `load_config()` — generic YAML loader |
+| `logger_setup.py` | File + stream logging with timestamped log files in `.log/` |
+| `config_bank.yaml` | Per-bank column mappings, date formats, import params, row filters |
+| `config_llm.yaml` | Model name, timeout, system prompt |
+| `categories.yaml` | Hierarchical expense categories |
+
+## How to Add a New Bank
+
+1. **Create a subfolder** in `data/` with the bank name (e.g., `data/mybank/`).
+2. **Place the export file** (CSV or Excel) in that subfolder.
+3. **Add a YAML block** to `config_bank.yaml`:
+   ```yaml
+   mybank:
+     import:              # Optional: pandas read_csv kwargs
+       sep: ","
+     columns_old:         # Column names in the bank's file
+       - TransactionDate
+       - Description
+       - Value
+       - Bank             # Use "Bank" as a placeholder — auto-filled with folder name
+       - Notes
+     columns_new:         # Must always be these five in this order
+       - Day
+       - Expense_name
+       - Amount
+       - Bank
+       - Comment
+     Day: "%Y-%m-%d"      # strftime format for date parsing
+     Remove:              # Optional: strings to filter out of Expense_name
+       - "Internal Transfer"
+   ```
+4. **Run the pipeline** — the new bank will be picked up automatically.
+
+If the bank has multiple export formats (like Revolut EN/IT), add a variant config key (e.g., `mybank_variant`) and extend `detect_bank_config()` in `main.py`.
+
+## How to Add a New Category
+
+1. **Edit** `import_bank_details/categories.yaml`:
+   ```yaml
+   NewPrimary:
+     - SubcategoryA
+     - SubcategoryB
+   ```
+   Or add a new subcategory under an existing primary:
+   ```yaml
+   Housing:
+     - Rent
+     - NewSubcategory
+   ```
+2. **No code changes needed** — `ExpenseType` enum is generated dynamically at import time.
+3. Optionally add a few-shot example in `data/examples/*.csv` to help the classifier learn the new category.
+
+## How to Modify Classification
+
+- **System prompt** — Edit `config_llm.yaml` → `system_prompt`.
+- **Model** — Change `config_llm.yaml` → `llm.model_name`.
+- **Few-shot examples** — Add/edit rows in `data/examples/*.csv` (columns: Day, Expense_name, Amount, Bank, Comment, Primary, Secondary).
+- **Online search** — Toggle `include_online_search` in `main.py:main()`. Adjust `max_results` in `search.py:perform_online_search()`.
+- **Parallel workers** — Change `max_workers` in `classify_expenses()` call (default 10).
+- **Temperature** — Set `temperature_base` in `config_llm.yaml` → `llm`.
+
+## Testing
+
+Run the test suite:
+
+```sh
+./run_tests.sh              # All tests
+./run_tests.sh --unit       # Unit tests only
+./run_tests.sh --integration # Integration tests only
+./run_tests.sh --extra "test_import"  # Pattern match
+./run_tests.sh -v           # Verbose mode
+```
+
+### Test markers
+
+| Marker | Meaning |
+|---|---|
+| *(default)* | Unit tests — no markers needed |
+| `@pytest.mark.integration` | Integration tests (require API keys) |
+| `@pytest.mark.e2e` | End-to-end tests |
+
+### Coverage
+
+Minimum 80% coverage required (`pyproject.toml` → `[tool.coverage.report]` → `fail_under = 80`).
+
+## CI/CD
+
+GitHub Actions runs on every push and PR to `main` (`.github/workflows/ci.yml`):
+
+1. **Black** — code formatting check
+2. **Flake8** — linting
+3. **isort** — import sorting check
+4. **mypy** — static type checking
+5. **pytest** — test suite with coverage (`--cov-fail-under=80`)
+6. **Codecov** — coverage report upload
+
+A separate `pre-commit.yml` workflow verifies pre-commit hooks.
+
+## Code Quality Settings
+
+| Tool | Setting |
+|---|---|
+| Line length | 130 characters |
+| Black | `line-length = 130` |
+| isort | `profile = "black"`, `line_length = 130` |
+| Flake8 | Config in `.flake8` |
+| mypy | `python_version = "3.11"`, `disallow_untyped_defs = true`, `warn_return_any = true`, `ignore_missing_imports = true` |
+| mypy (tests) | `disallow_untyped_defs = false` |


### PR DESCRIPTION
## Summary

- Created `docs/ARCHITECTURE.md` — tech stack, system overview, data flow, key design decisions
- Created `docs/ABSTRACTIONS.md` — domain models (bank config, category taxonomy, expense data models, classification pipeline, search/caching)
- Created `docs/GETTING_STARTED.md` — directory structure, key files, how to add banks/categories, testing, CI/CD, code quality settings
- Created `CLAUDE.md` — concise AI assistant quick-reference with commands, constraints, and doc pointers
- Slimmed `README.md` to a public-facing overview (features, install, usage, testing) with a pointer to `docs/`

Follows a three-tier documentation hierarchy ordered by change frequency (most stable → most volatile), based on the [refactoring.fm AI coding workflow](https://refactoring.fm/p/my-ai-coding-workflow).

## Test plan

- [ ] Verify all doc links resolve correctly (CLAUDE.md → docs/, README.md → docs/)
- [ ] Confirm README.md still has everything needed to clone, install, and run
- [ ] Cross-reference ARCHITECTURE.md against source code for accuracy
- [ ] Cross-reference ABSTRACTIONS.md against Pydantic models and config files
- [ ] Confirm no stale references across all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)